### PR TITLE
Add 'label' parameter after colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 
 | Parameter      | Description                                                           |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<name_of_function>(x)=<math_equation>, <color>`| **Function to plot** in terms of `x`. It can have any name, as long as it ends with `(x)`. Color can be omitted. You can add as many as you want. |
-| `<name_of_function>(x,y)=<math_equation>, <color>`| **3D Function to plot** in terms of `x` and `y`. It can have any name, as long as it ends with `(x,y)`. Color can be omitted. You can add as many as you want. |
+| `<name_of_function>(x)=<math_equation>, <color>, <label>`| **Function to plot** in terms of `x`. It can have any name, as long as it ends with `(x)`. Color and label can be omitted. You can add as many as you want. |
+| `<name_of_function>(x,y)=<math_equation>, <color>, <label>`| **3D Function to plot** in terms of `x` and `y`. It can have any name, as long as it ends with `(x,y)`. Color can be omitted. You can add as many as you want. |
 | `scatter=<x>,<y>,<color>,<label> ; <x2>,<y2>...`| **Points to render on the graph**. Multiple points must be separated with a `;`. Color and label can be omitted, but if not, they have to be in the **specified order** |
 | `xmin=<number>`| **Start of the range** on the x-axis that will be plotted |
 | `xmax=<number>`| **End of the range** on the x-axis that will be plotted |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 | Parameter      | Description                                                           |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `<name_of_function>(x)=<math_equation>, <color>, <label>`| **Function to plot** in terms of `x`. It can have any name, as long as it ends with `(x)`. Color and label can be omitted. You can add as many as you want. |
-| `<name_of_function>(x,y)=<math_equation>, <color>, <label>`| **3D Function to plot** in terms of `x` and `y`. It can have any name, as long as it ends with `(x,y)`. Color can be omitted. You can add as many as you want. |
+| `<name_of_function>(x,y)=<math_equation>, <color>`| **3D Function to plot** in terms of `x` and `y`. It can have any name, as long as it ends with `(x,y)`. Color can be omitted. You can add as many as you want. |
 | `scatter=<x>,<y>,<color>,<label> ; <x2>,<y2>...`| **Points to render on the graph**. Multiple points must be separated with a `;`. Color and label can be omitted, but if not, they have to be in the **specified order** |
 | `xmin=<number>`| **Start of the range** on the x-axis that will be plotted |
 | `xmax=<number>`| **End of the range** on the x-axis that will be plotted |

--- a/juliaplots.jl
+++ b/juliaplots.jl
@@ -189,7 +189,7 @@ function main()
 
             # Draw the surface plot and add parameters
             surface!(plt, collect(x), collect(y), z,
-                label="woops",
+                label=label_dict[name],
                 color=color_dict[name],
                 linewidth=0,
                 fillalpha=0.8,
@@ -249,7 +249,7 @@ function main()
             if length(coords) >= 2
                 xp = parse(Float64, coords[1])
                 yp = parse(Float64, coords[2])
-                color = (length(coords) > 2) ? coords[3] : scatter_color
+                color = (length(coords) > 2) && !isempty(coords[3]) ? coords[3] : scatter_color
                 label = (length(coords) > 3) ? coords[4] : "($xp, $yp)"
                 scatter!(plt, [xp], [yp], label=label, color=color)
             else

--- a/juliaplots.jl
+++ b/juliaplots.jl
@@ -29,7 +29,7 @@ function main()
 
     # Parse the command line arguments
     args = parse_args(ARGS)
-    
+
     # Validate that at least one function is provided
     if !any(endswith(k, "(x)") || endswith(k, "(x,y)") for k in keys(args))
         println("No functions provided. Use f(x)=... or g(x,y)=...")
@@ -40,30 +40,43 @@ function main()
     # Also extract the color for each function if provided
     f2d_dict = Dict{String, Function}()
     color_dict = Dict{String, String}()
+    label_dict = Dict{String, String}()
     for(k,v) in args
         if endswith(k,"(x)")
             parts = split(v, ",")
             equation = strip(parts[1])
             f2d_dict[k] = eval(Meta.parse("x -> $equation"))
+            color_dict[k] = get(args, "color", "blue")
             if length(parts) > 1
-                color_dict[k] = strip(parts[2])
-            else
-                color_dict[k] = get(args, "color", "blue")
+                color_value = strip(parts[2])
+                color_dict[k] = isempty(color_value) ? color_dict[k] : color_value
+            end
+
+            label_dict[k] = split(v, ",")[1]
+            if length(parts) > 2
+                label_value = strip(parts[3])
+                label_dict[k] = isempty(label_value) ? label_dict[k] : label_value
             end
         end
     end
 
     # Find all 3D functions. Any key that ends with '(x,y)' is considered a 3D function
     f3d_dict = Dict{String, Function}()
-    for(k,v) in args 
+    for(k,v) in args
         if endswith(k,"(x,y)")
             parts = split(v,",")
             equation = strip(parts[1])
             f3d_dict[k] = eval(Meta.parse("function(x,y) $equation end"))
+            color_dict[k] = get(args, "color", "blue")
             if length(parts) > 1
-                color_dict[k] = strip(parts[2])
-            else
-                color_dict[k] = get(args, "color", "blue")
+                color_value = strip(parts[2])
+                color_dict[k] = isempty(color_value) ? color_dict[k] : color_value
+            end
+
+            label_dict[k] = split(v, ",")[1]
+            if length(parts) > 2
+                label_value = strip(parts[3])
+                label_dict[k] = isempty(label_value) ? label_dict[k] : label_value
             end
         end
     end
@@ -176,7 +189,7 @@ function main()
 
             # Draw the surface plot and add parameters
             surface!(plt, collect(x), collect(y), z,
-                label=split(args[name],",")[1],
+                label="woops",
                 color=color_dict[name],
                 linewidth=0,
                 fillalpha=0.8,
@@ -221,7 +234,7 @@ function main()
             # Draw
             plot!(plt,
                 x, y,
-                label=split(args[name],",")[1],
+                label=label_dict[name],
                 color=color_dict[name],
                 linewidth=line_width
             )


### PR DESCRIPTION
Support setting the label for 2D plots

Example:

```juliaplots
f(x) = x^2 ./ 5, red
g(x) = 1 ./ x, blue, Reciprocal
h(x) = sqrt(x),, h(x)
```

<img width="507" height="353" alt="Screenshot 2025-09-22 at 22 19 59" src="https://github.com/user-attachments/assets/6383d3a2-ff34-48a5-b08f-9e618726745a" />

This is particularly useful for longer equations.
